### PR TITLE
Allow default presenters to be overridden

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,6 @@ ext {
     artifactPrefix = 'rmvp'
     groupId = 'com.xfinity'
     uploadName = 'rmvp'
-    publishVersion = '0.9.3'
+    publishVersion = '0.9.4'
     description = 'RecyclerView MVP Library'
 }


### PR DESCRIPTION
Previously you could only pass in a presenter to use for a component
if the component's view type had no default presenter registered.

This change allows you to override the default presenter for any
component by setting the Component's presenter field